### PR TITLE
Getting Stable-Diffusion Docker Setup to work with AMD 6900xt Graphic Card.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,14 @@ services:
       - /dev/dri:/dev/dri
     environment:
       # VERY COMMON NEED ENVIRONMENT VARIABLE
-      - HSA_OVERRIDE_GFX_VERSION=10.3.4
-    image: 1naforever/stable-diffusion-rocm:latest
+      - HSA_OVERRIDE_GFX_VERSION=10.3.0
+      # Allows for more use of the VRAM cache
+      - PYTORCH_HIP_ALLOC_CONF=garbage_collection_threshold:0.9,max_split_size_mb:256
+    image: stable-diff:latest
+    build:
+      context: .
+      dockerfile: ./Dockerfile
     ipc: host
-    network_mode: "host"
     security_opt:
       - seccomp:unconfined
     volumes:
@@ -19,6 +23,11 @@ services:
       - models:/sd/models
       - plugins:/sd/plugins
       - outputs:/sd/outputs
+    ports:
+      - 7860:7860
+    group_add:
+      - video
+      - render
 volumes:
   modules:
   models:


### PR DESCRIPTION
Getting stable-diffusion to work on an amd 6900xt graphics card.

The following changes:

docker-compose:
  - Added HIP_ALLOC_CONF to allow stable diffusion to use more vram ( can create batchs up to 4 photos at the same time)
  - GFX version to 10.3.0 ( needed for amd 6900xt )
  - Docker compose file can now build the docker image
  - Added video and render groups, to garentee access to video cards ( may work on dropping root pivilages in the future)
  - I personally do not like the host networking, I rather express how the ports are forwarded.

Dockerfile
 - when Automatic111 attempts to install torch, it will install a rogue version of torch with nvidia cuda. Since Torch is already installed using the pytorch base image, no need to reinstall it again.
 - forced pip to install a version of numpy that can be used.
 - used the --listen flag to have a 0.0.0.0 listening address for my server.

Thank you for this amazing docker setup, saved me quite a bit of time.

- erik.